### PR TITLE
Add simple Docker setup for API for haystack and ollama

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.env
+.venv/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Docker
+*.log
+docker/*.log
+
+# VSCode
+.vscode/
+
+# Models
+models/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM python:3.11-slim
 # System dependencies for ollama-haystack
 RUN apt-get update && apt-get install -y \
     curl \
-    jq \
     && rm -rf /var/lib/apt/lists/*
 
 # Set workdir

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.11-slim
+
+# System dependencies for ollama-haystack
+RUN apt-get update && apt-get install -y \
+    curl \
+    jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set workdir
+WORKDIR /app
+
+# Copy requirements first for layer caching
+COPY requirements.txt ./
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the code
+COPY . .
+
+# Expose FastAPI port
+EXPOSE 8000
+
+# Entrypoint for development
+CMD ["uvicorn", "src.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# openproject-haystack
+# OpenProject haystack
 
 This project is an AI-powered application using [Haystack](https://github.com/deepset-ai/haystack) and [llama.cpp](https://github.com/ggerganov/llama.cpp) for natural language processing. The project is containerized with Docker for both development and deployment.
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3.8'
+services:
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - haystack-internal
+    command: serve
+
+  api:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    volumes:
+      - ../src:/app/src
+      - ../.env:/app/.env
+    ports:
+      - "8000:8000"
+    depends_on:
+      - ollama
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - openproject_network
+      - haystack-internal
+    command: uvicorn src.app:app --host 0.0.0.0 --port 8000
+
+
+volumes:
+  ollama-data:
+
+networks:
+  openproject_network:
+    external: true
+  haystack-internal:
+    driver: bridge
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   ollama:
     image: ollama/ollama
@@ -21,7 +20,6 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ../src:/app/src
-      - ../.env:/app/.env
     ports:
       - "8000:8000"
     depends_on:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+haystack
+ollama-haystack

--- a/src/app.py
+++ b/src/app.py
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 #-- copyright
 # OpenProject is an open source project management software.

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from haystack_integrations.components.generators.ollama import OllamaGenerator
+
+app = FastAPI()
+
+class Prompt(BaseModel):
+    prompt: str
+
+generator = OllamaGenerator(
+    model="mistral:latest",
+    url="http://ollama:11434",
+    generation_kwargs={"num_predict": 1000, "temperature": 0.7}
+)
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+@app.post("/generate")
+def generate(data: Prompt):
+    try:
+        result = generator.run(data.prompt)
+        return {"response": result["replies"][0]}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
Add a simple Docker setup for the API endpoint to use with `haystack` and `ollama`. 
This container works in the [OpenProject](https://github.com/opf/openproject) development network. 

### Adding a LLM

By default, the ollama container does not include any language models. You need to install one manually.

1. Make sure containers are built and running:
```bash
docker-compose -f docker/docker-compose.yml up --build -d
```

The container might fail and shut down because of Ollama. It's fine; without an LLM model, Ollama won't respond to health checks. 

2. Pull a language model (e.g. Mistral):
```bash
  docker exec -it docker-ollama-1 ollama pull mistral:latest
```
> You can also use mistral:latest, llama3, phi3, or any other supported Ollama model.

### Test local development

To test if everything is working run:
```bash
curl -X POST http://localhost:8000/generate \
     -H 'Content-Type: application/json' \
     -d '{"prompt": "Who let the dogs out?"}'
```

### Next steps

The next step will be to replace `ollama` with `llama.cpp`. 